### PR TITLE
feat(rewards_exporter): migrate to Livepeer subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The `orch_info_exporter` fetches metrics about the Livepeer orchestrator from th
 
 ### orch_rewards_exporter
 
-The `orch_rewards_exporter` fetches reward data for the Livepeer orchestrator from the `https://stronk.rocks/api/livepeer/getAllRewardEvents` endpoint and filters it based on the orchestrator ID. These metrics provide insights into the rewards the orchestrator claims, including the total claimed rewards and details about each rewarded transaction. They include:
+The `orch_rewards_exporter` fetches reward data for the Livepeer orchestrator from the [Livepeer subgraph](https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one/graphql) endpoint. These metrics provide insights into the rewards the orchestrator claims, including the total claimed rewards and details about each reward transaction. They include:
 
 **Gauge metrics:**
 
@@ -157,9 +157,10 @@ The `orch_rewards_exporter` fetches reward data for the Livepeer orchestrator fr
 **GaugeVec metrics:**
 
 - `livepeer_orch_reward_amount`: This metric represents the rewards earned by each transaction. It can be used to understand the distribution of rewards among transactions. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
-- `livepeer_orch_reward_transaction_hash`: This metric represents the hash of each rewarded transaction. It can track the transactions in which the orchestrator claimed rewards. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
-- `livepeer_orch_reward_block_number`: This metric represents the block number for each rewarded transaction. It can be used to track when the orchestrator claimed rewards. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
-- `livepeer_orch_reward_block_time`: This metric represents the block time for each rewarded transaction. It can be used to understand when the orchestrator claimed rewards. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
+- `livepeer_orch_reward_gas_used`: This metric represents the gas used in each reward transaction. It can be used to understand the gas cost of reward transactions. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
+- `livepeer_orch_reward_block_number`: This metric represents the block number for each reward transaction. It can be used to track when the orchestrator claimed rewards. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
+- `livepeer_orch_reward_block_time`: This metric represents the block time for each reward transaction. It can be used to understand when the orchestrator claimed rewards. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
+- `livepeer_orch_reward_round`: This metric represents the round in which each reward transaction was claimed. It can be used to track the rounds in which the orchestrator claimed rewards. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
 
 ### orch_score_exporter
 
@@ -189,13 +190,12 @@ The `orch_test_streams_exporter` fetches metrics about the Livepeer orchestrator
 
 ### orch_tickets_exporter
 
-The `orch_tickets_exporter` fetches and exposes winning ticket transaction information from the [Livepeer subgraph](https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one/graphql). These metrics provide insights into the winning tickets of the orchestrator, including the amount won, gas used, transaction hash, block number, block time, and protocol round. They include:
+The `orch_tickets_exporter` fetches and exposes winning ticket transaction information from the [Livepeer subgraph](https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one/graphql) endpoint. These metrics provide insights into the winning tickets of the orchestrator, including the amount won, gas used, transaction hash, block number, block time, and protocol round. They include:
 
 **GaugeVec metrics:**
 
 - `livepeer_orch_winning_ticket_amount`: This metric represents the fees won by each winning orchestrator ticket. It can be used to track the earnings of the orchestrator from winning tickets. This GaugeVec includes the label `id`, which represents the unique identifier of each ticket.
 - `livepeer_orch_winning_ticket_gas_used`: This metric represents the gas used in redeeming each winning ticket. It can be used to understand the gas cost of winning tickets. This GaugeVec includes the label `id`, which represents the unique identifier of each ticket.
-- `livepeer_orch_winning_ticket_transaction_hash`: This metric represents the transaction hash for each winning ticket. It can track the transactions in which the orchestrator won tickets. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
 - `livepeer_orch_winning_ticket_block_number`: This metric represents the block number for each winning ticket. It can be used to track when the orchestrator won tickets. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
 - `livepeer_orch_winning_ticket_block_time`: This metric represents the block time for each winning ticket. It can be used to understand when the orchestrator won tickets. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.
 - `livepeer_orch_winning_ticket_round`: This metric represents the round in which each winning ticket was won. It can be used to track the rounds in which the orchestrator won tickets. This GaugeVec includes the label `id`, which represents the unique identifier of the transaction in which the ticket was won.

--- a/exporters/orch_rewards_exporter/orch_rewards_exporter.go
+++ b/exporters/orch_rewards_exporter/orch_rewards_exporter.go
@@ -1,9 +1,10 @@
 // Package orch_rewards_exporter implements a Livepeer orchestrator rewards exporter that fetches
-// data from the https://stronk.rocks/api/livepeer/getAllRewardEvents API endpoint and exposes
-// information about the orchestrator's rewards via Prometheus metrics.
+// data  Livepeer subgraph GraphQL API endpoint and exposes information about the orchestrator's rewards
+// via Prometheus metrics.
 package orch_rewards_exporter
 
 import (
+	"fmt"
 	"livepeer-exporter/fetcher"
 	"strconv"
 	"sync"
@@ -13,43 +14,70 @@ import (
 )
 
 var (
-	getRewardEventsEndpoint = "https://stronk.rocks/api/livepeer/getAllRewardEvents"
+	rewardEventsEndpoint = "https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one"
 )
 
-// rewardTransaction represents the structure of the reward transaction field contained in the API response.
-type rewardTransaction struct {
-	Address         string
-	Amount          float64
-	TransactionHash string
-	BlockNumber     int
-	BlockTime       int
+// graphqlQuery represents the GraphQL query to fetch data from the GraphQL API.
+const graphqlQueryTemplate = `
+{
+	rewardEvents(where: {delegate: "%s"}) {
+		transaction {
+			gasUsed
+			blockNumber
+			timestamp
+			id
+		}
+		round {
+			id
+		}
+		rewardTokens
+	}
+}
+`
+
+// rewardEvent represents the structure of the rewardEvent field contained in the GraphQL API response.
+type rewardEvent struct {
+	Transaction struct {
+		GasUsed     string
+		BlockNumber string
+		Timestamp   int
+		ID          string
+	}
+	Round struct {
+		ID string
+	}
+	RewardTokens string
 }
 
-// rewards represents the structure of the data returned by the API.
-type rewards struct {
+// rewardEventResponse represents the structure of the GraphQL API response.
+type rewardEventResponse struct {
 	sync.Mutex
 
 	// Response data.
-	Transactions []rewardTransaction
+	Data struct {
+		RewardEvents []rewardEvent
+	}
 }
 
 // OrchRewardsExporter fetches data from the API and exposes orchestrator's rewards metrics via Prometheus.
 type OrchRewardsExporter struct {
 	// Metrics.
-	RewardAmount          *prometheus.GaugeVec
-	RewardTransactionHash *prometheus.GaugeVec
-	RewardBlockNumber     *prometheus.GaugeVec
-	RewardBlockTime       *prometheus.GaugeVec
-	TotalReward           prometheus.Gauge
+	RewardAmount      *prometheus.GaugeVec
+	RewardGasUsed     *prometheus.GaugeVec
+	RewardBlockNumber *prometheus.GaugeVec
+	RewardBlockTime   *prometheus.GaugeVec
+	TotalReward       prometheus.Gauge
+	RewardRound       *prometheus.GaugeVec
 
 	// Config settings.
-	orchAddress         string        // The orchestrator address to filter rewards by.
-	fetchInterval       time.Duration // How often to fetch data.
-	updateInterval      time.Duration // How often to update metrics.
-	orchRewardsEndpoint string        // The endpoint to fetch data from.
+	orchAddress             string        // The orchestrator address to filter rewards by.
+	fetchInterval           time.Duration // How often to fetch data.
+	updateInterval          time.Duration // How often to update metrics.
+	orchRewardsEndpoint     string        // The endpoint to fetch data from.
+	orchRewardsGraphqlQuery string        // The GraphQL query to fetch data from the GraphQL API.
 
 	// Data.
-	orchRewards *rewards // The data returned by the API.
+	orchRewards *rewardEventResponse // The data returned by the API.
 
 	// Fetchers.
 	orchRewardsFetcher fetcher.Fetcher
@@ -64,24 +92,24 @@ func (m *OrchRewardsExporter) initMetrics() {
 		},
 		[]string{"id"},
 	)
-	m.RewardTransactionHash = prometheus.NewGaugeVec(
+	m.RewardGasUsed = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "livepeer_orch_reward_transaction_hash",
-			Help: "The transaction hash for each rewarded transaction.",
+			Name: "livepeer_orch_reward_gas_used",
+			Help: "The amount of gas used by each reward transaction.",
 		},
 		[]string{"id"},
 	)
 	m.RewardBlockNumber = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "livepeer_orch_reward_block_number",
-			Help: "The block number for each rewarded transaction.",
+			Help: "The block number for each reward transaction.",
 		},
 		[]string{"id"},
 	)
 	m.RewardBlockTime = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "livepeer_orch_reward_block_time",
-			Help: "The block time for each rewarded transaction.",
+			Help: "The block time for each reward transaction.",
 		},
 		[]string{"id"},
 	)
@@ -91,62 +119,67 @@ func (m *OrchRewardsExporter) initMetrics() {
 			Help: "Total rewards claimed by the the orchestrator.",
 		},
 	)
+	m.RewardRound = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "livepeer_orch_reward_round",
+			Help: "The round in which each reward was claimed.",
+		},
+		[]string{"id"},
+	)
 }
 
 // registerMetrics registers the orchestrator rewards metrics with Prometheus.
 func (m *OrchRewardsExporter) registerMetrics() {
 	prometheus.MustRegister(
 		m.RewardAmount,
-		m.RewardTransactionHash,
+		m.RewardGasUsed,
 		m.RewardBlockNumber,
 		m.RewardBlockTime,
 		m.TotalReward,
+		m.RewardRound,
 	)
 }
 
-// updateMetrics updates the metrics with the data fetched from the stronk.rocks rewards API.
+// updateMetrics updates the metrics with the data fetched the Livepeer subgraph GraphQL API.
 func (m *OrchRewardsExporter) updateMetrics() {
-	// Filter out rewards that are not for the configured orchestrator.
-	var rewards []rewardTransaction
-	for _, reward := range m.orchRewards.Transactions {
-		if reward.Address == m.orchAddress {
-			rewards = append(rewards, reward)
-		}
-	}
-
 	// Set the metrics for each reward.
-	for _, reward := range rewards {
-		amount, _ := strconv.ParseFloat(strconv.FormatFloat(reward.Amount, 'f', -1, 64), 64)
-		blockNumber, _ := strconv.ParseFloat(strconv.Itoa(reward.BlockNumber), 64)
-		blockTime, _ := strconv.ParseFloat(strconv.Itoa(reward.BlockTime), 64)
-
-		m.RewardAmount.WithLabelValues(reward.TransactionHash).Set(amount)
-		m.RewardBlockNumber.WithLabelValues(reward.TransactionHash).Set(blockNumber)
-		m.RewardBlockTime.WithLabelValues(reward.TransactionHash).Set(blockTime * 1000) // Grafana expects milliseconds.
-	}
-
-	// Calculate the total rewards.
 	var total float64
-	for _, reward := range rewards {
-		total += reward.Amount
+	for _, reward := range m.orchRewards.Data.RewardEvents {
+		amount, _ := strconv.ParseFloat(reward.RewardTokens, 64)
+		gasUsed, _ := strconv.ParseFloat(reward.Transaction.GasUsed, 64)
+		blockNumber, _ := strconv.ParseFloat(reward.Transaction.BlockNumber, 64)
+		blockTime, _ := strconv.ParseFloat(strconv.Itoa(reward.Transaction.Timestamp), 64)
+		round, _ := strconv.ParseFloat(reward.Round.ID, 64)
+
+		m.RewardAmount.WithLabelValues(reward.Transaction.ID).Set(amount)
+		m.RewardGasUsed.WithLabelValues(reward.Transaction.ID).Set(gasUsed)
+		m.RewardBlockNumber.WithLabelValues(reward.Transaction.ID).Set(blockNumber)
+		m.RewardBlockTime.WithLabelValues(reward.Transaction.ID).Set(blockTime * 1000) // Grafana expects milliseconds.
+		m.RewardRound.WithLabelValues(reward.Transaction.ID).Set(round)
+
+		// Calculate the total rewards.
+		total += amount
 	}
+
+	// Set the total rewards metric.
 	m.TotalReward.Set(total)
 }
 
 // NewOrchRewardsExporter creates a new OrchRewardsExporter.
 func NewOrchRewardsExporter(orchAddress string, fetchInterval time.Duration, updateInterval time.Duration) *OrchRewardsExporter {
 	exporter := &OrchRewardsExporter{
-		orchAddress:         orchAddress,
-		fetchInterval:       fetchInterval,
-		updateInterval:      updateInterval,
-		orchRewardsEndpoint: getRewardEventsEndpoint,
-		orchRewards:         &rewards{},
+		orchAddress:             orchAddress,
+		fetchInterval:           fetchInterval,
+		updateInterval:          updateInterval,
+		orchRewardsEndpoint:     rewardEventsEndpoint,
+		orchRewardsGraphqlQuery: fmt.Sprintf(graphqlQueryTemplate, orchAddress),
+		orchRewards:             &rewardEventResponse{},
 	}
 
 	// Initialize fetcher.
 	exporter.orchRewardsFetcher = fetcher.Fetcher{
 		URL:  exporter.orchRewardsEndpoint,
-		Data: &exporter.orchRewards.Transactions,
+		Data: &exporter.orchRewards,
 	}
 
 	// Initialize metrics.
@@ -159,7 +192,7 @@ func NewOrchRewardsExporter(orchAddress string, fetchInterval time.Duration, upd
 // Start starts the OrchRewardsExporter.
 func (m *OrchRewardsExporter) Start() {
 	// Fetch initial data and update metrics.
-	m.orchRewardsFetcher.FetchDataWithBody(`{"smartUpdate":false}`)
+	m.orchRewardsFetcher.FetchGraphQLData(m.orchRewardsGraphqlQuery)
 	m.updateMetrics()
 
 	// Start fetcher in a goroutine.
@@ -169,7 +202,7 @@ func (m *OrchRewardsExporter) Start() {
 
 		for range ticker.C {
 			m.orchRewards.Mutex.Lock()
-			m.orchRewardsFetcher.FetchDataWithBody(`{"smartUpdate":false}`)
+			m.orchRewardsFetcher.FetchGraphQLData(m.orchRewardsGraphqlQuery)
 			m.orchRewards.Mutex.Unlock()
 		}
 	}()


### PR DESCRIPTION
This commit migrates the orch_rewards_exporter to the [Livepeer subgraph](https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one/graphql) (see #54).
