### PR TITLE
feat(delegators_exporter): migrate to Livepeer subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The `crypto_prices_exporter` fetches and exposes the prices of different cryptoc
 
 ### orch_delegators_exporter
 
-The `orch_delegators_exporter` fetches metrics about the delegators of the set Livepeer orchestrator from the `https://stronk.rocks/api/livepeer/getOrchestrator/` endpoint. These metrics provide insights into the number and behaviour of the delegators that stake with the orchestrator, including the total number of delegators, the bonded amount of each delegator, and the start round. They include:
+The `orch_delegators_exporter` fetches metrics about the delegators of the set Livepeer orchestrator from the [Livepeer subgraph](https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one/graphql) endpoint. These metrics provide insights into the number and behaviour of the delegators that stake with the orchestrator, including the total number of delegators, the bonded amount of each delegator, the start round, and the fees collected by each delegator. They include:
 
 **Gauge metrics:**
 
@@ -122,6 +122,7 @@ The `orch_delegators_exporter` fetches metrics about the delegators of the set L
 
 - `livepeer_orch_delegator_bonded_amount`: This metric represents the bonded amount of each delegator address. It can be used to understand the distribution of stakes among delegators. This GaugeVec includes the label `id`, representing the delegator's address.
 - `livepeer_orch_delegator_start_round`: This metric represents the start round for each delegator. It can be used to track the longevity and loyalty of delegators. This GaugeVec includes the label `id`, representing the delegator's address.
+- `livepeer_orch_delegator_collected_fees`: This metric represents the fees collected by each delegator. It can be used to track the earnings of delegators from fees. This GaugeVec includes the label `id`, representing the delegator's address.
 
 ### orch_info_exporter
 

--- a/exporters/orch_delegators_exporter/orch_delegators_exporter.go
+++ b/exporters/orch_delegators_exporter/orch_delegators_exporter.go
@@ -1,6 +1,6 @@
-// Package orch_delegators_exporter implements a Livepeer orchestrator elegators exporter that
-// fetches data from the https://stronk.rocks/api/livepeer/getOrchestrator/ API endpoint and exposes
-// information about the orchestrator's delegators via Prometheus metrics.
+// Package orch_delegators_exporter implements a Livepeer orchestrator delegators exporter that
+// fetches data from the Livepeer subgraph GraphQL API endpoint and exposes information about
+// the orchestrator's delegators via Prometheus metrics.
 package orch_delegators_exporter
 
 import (
@@ -14,22 +14,37 @@ import (
 )
 
 var (
-	orchDelegatorsEndpointTemplate = "https://stronk.rocks/api/livepeer/getOrchestrator/%s"
+	delegatorsEndpoint = "https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one"
 )
 
-// delegator represents the structure of the delegators field contained in the API response.
+// graphqlQuery represents the GraphQL query to fetch data from the GraphQL API.
+const graphqlQueryTemplate = `
+{
+	delegators (where:{delegate:"%s"}){
+		id
+		startRound
+		bondedAmount
+		fees
+	}
+}
+`
+
+// delegatorsResponse represents the structure of the delegators field contained in the GraphQL API response.
 type delegator struct {
 	ID           string
-	BondedAmount string
 	StartRound   string
+	BondedAmount string
+	Fees         string
 }
 
-// orchDelegators represents the structure of the data returned by the API.
-type orchDelegators struct {
+// delegatorsResponse represents the structure of the GraphQL API response.
+type delegatorsResponse struct {
 	sync.Mutex
 
 	// Response data.
-	Delegators []delegator
+	Data struct {
+		Delegators []delegator
+	}
 }
 
 // OrchDelegatorsExporter fetches data from the API and exposes orchestrator's delegators metrics via Prometheus.
@@ -38,14 +53,16 @@ type OrchDelegatorsExporter struct {
 	BondedAmount   *prometheus.GaugeVec
 	StartRound     *prometheus.GaugeVec
 	DelegatorCount prometheus.Gauge
+	CollectedFees  *prometheus.GaugeVec
 
 	// Config settings.
-	fetchInterval          time.Duration // How often to fetch data.
-	updateInterval         time.Duration // How often to update metrics.
-	orchDelegatorsEndpoint string        // The endpoint to fetch data from.
+	fetchInterval              time.Duration // How often to fetch data.
+	updateInterval             time.Duration // How often to update metrics.
+	orchDelegatorsEndpoint     string        // The endpoint to fetch data from.
+	orchDelegatorsGraphqlQuery string        // The GraphQL query to fetch data from the GraphQL API.
 
 	// Data.
-	orchDelegators *orchDelegators // The data returned by the API.
+	orchDelegators *delegatorsResponse // The data returned by the API.
 
 	// Fetchers.
 	orchDelegatorsFetcher fetcher.Fetcher
@@ -67,6 +84,13 @@ func (m *OrchDelegatorsExporter) initMetrics() {
 		},
 		[]string{"id"},
 	)
+	m.CollectedFees = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "livepeer_orch_delegator_collected_fees",
+			Help: "The amount of fees collected by each delegator.",
+		},
+		[]string{"id"},
+	)
 	m.DelegatorCount = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "livepeer_orch_delegator_count",
@@ -81,31 +105,35 @@ func (m *OrchDelegatorsExporter) registerMetrics() {
 		m.BondedAmount,
 		m.StartRound,
 		m.DelegatorCount,
+		m.CollectedFees,
 	)
 }
 
 // updateMetrics updates the metrics with the data fetched from the stonk.rocks orchestrator API.
 func (m *OrchDelegatorsExporter) updateMetrics() {
 	// Set the DelegatorCount metric by counting the length of the Delegators slice.
-	m.DelegatorCount.Set(float64(len(m.orchDelegators.Delegators)))
+	m.DelegatorCount.Set(float64(len(m.orchDelegators.Data.Delegators)))
 
 	// Set the BondedAmount and StartRound metrics for each delegator.
-	for _, delegator := range m.orchDelegators.Delegators {
+	for _, delegator := range m.orchDelegators.Data.Delegators {
 		bondedAmount, _ := strconv.ParseFloat(delegator.BondedAmount, 64)
 		startRound, _ := strconv.ParseFloat(delegator.StartRound, 64)
+		feesCollected, _ := strconv.ParseFloat(delegator.Fees, 64)
 
 		m.BondedAmount.WithLabelValues(delegator.ID).Set(bondedAmount)
 		m.StartRound.WithLabelValues(delegator.ID).Set(startRound)
+		m.CollectedFees.WithLabelValues(delegator.ID).Set(feesCollected)
 	}
 }
 
 // NewOrchDelegatorsExporter creates a new OrchDelegatorsExporter.
 func NewOrchDelegatorsExporter(orchAddress string, fetchInterval time.Duration, updateInterval time.Duration) *OrchDelegatorsExporter {
 	exporter := &OrchDelegatorsExporter{
-		fetchInterval:          fetchInterval,
-		updateInterval:         updateInterval,
-		orchDelegatorsEndpoint: fmt.Sprintf(orchDelegatorsEndpointTemplate, orchAddress),
-		orchDelegators:         &orchDelegators{},
+		fetchInterval:              fetchInterval,
+		updateInterval:             updateInterval,
+		orchDelegatorsEndpoint:     delegatorsEndpoint,
+		orchDelegatorsGraphqlQuery: fmt.Sprintf(graphqlQueryTemplate, orchAddress),
+		orchDelegators:             &delegatorsResponse{},
 	}
 
 	// Initialize fetcher.
@@ -124,7 +152,7 @@ func NewOrchDelegatorsExporter(orchAddress string, fetchInterval time.Duration, 
 // Start starts the OrchDelegatorsExporter.
 func (m *OrchDelegatorsExporter) Start() {
 	// Fetch initial data and update metrics.
-	m.orchDelegatorsFetcher.FetchData()
+	m.orchDelegatorsFetcher.FetchGraphQLData(m.orchDelegatorsGraphqlQuery)
 	m.updateMetrics()
 
 	// Start fetcher in a goroutine.
@@ -134,7 +162,7 @@ func (m *OrchDelegatorsExporter) Start() {
 
 		for range ticker.C {
 			m.orchDelegators.Mutex.Lock()
-			m.orchDelegatorsFetcher.FetchData()
+			m.orchDelegatorsFetcher.FetchGraphQLData(m.orchDelegatorsGraphqlQuery)
 			m.orchDelegators.Mutex.Unlock()
 		}
 	}()

--- a/exporters/orch_rewards_exporter/orch_rewards_exporter.go
+++ b/exporters/orch_rewards_exporter/orch_rewards_exporter.go
@@ -1,5 +1,5 @@
 // Package orch_rewards_exporter implements a Livepeer orchestrator rewards exporter that fetches
-// data  Livepeer subgraph GraphQL API endpoint and exposes information about the orchestrator's rewards
+// data from the Livepeer subgraph GraphQL API endpoint and exposes information about the orchestrator's rewards
 // via Prometheus metrics.
 package orch_rewards_exporter
 


### PR DESCRIPTION
This pull request migrates the `orch_delegators_exporter` to the [Livepeer subgraph](https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one/graphql) endpoint (see #54).
