### PR TITLE
feat(info_exporter): migrate to Livepeer subgraph

### DIFF
--- a/exporters/orch_delegators_exporter/orch_delegators_exporter.go
+++ b/exporters/orch_delegators_exporter/orch_delegators_exporter.go
@@ -20,7 +20,7 @@ var (
 // graphqlQuery represents the GraphQL query to fetch data from the GraphQL API.
 const graphqlQueryTemplate = `
 {
-	delegators (where:{delegate:"%s"}){
+	delegators(where: {delegate: "%s"}) {
 		id
 		startRound
 		bondedAmount

--- a/exporters/orch_tickets_exporter/orch_tickets_exporter.go
+++ b/exporters/orch_tickets_exporter/orch_tickets_exporter.go
@@ -20,9 +20,7 @@ var (
 // graphqlQuery represents the GraphQL query to fetch data from the GraphQL API.
 const graphqlQueryTemplate = `
 {
-	winningTicketRedeemedEvents(
-		where: {recipient: "%s"}
-	) {
+	winningTicketRedeemedEvents(where: {recipient: "%s"}) {
 		transaction {
 			gasUsed
 			blockNumber

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -66,13 +67,13 @@ func main() {
 	log.Println("Starting Livepeer exporter...")
 
 	// Retrieve orchestrator address.
-	orchAddr := os.Getenv("LIVEPEER_EXPORTER_ORCHESTRATOR_ADDRESS")
+	orchAddr := strings.ToLower(os.Getenv("LIVEPEER_EXPORTER_ORCHESTRATOR_ADDRESS"))
 	if orchAddr == "" {
 		log.Fatal("'LIVEPEER_EXPORTER_ORCHESTRATOR_ADDRESS' environment variable should be set")
 	}
 
 	// Retrieve secondary orchestrator address.
-	orchAddrSecondary := os.Getenv("LIVEPEER_EXPORTER_ORCHESTRATOR_ADDRESS_SECONDARY")
+	orchAddrSecondary := strings.ToLower(os.Getenv("LIVEPEER_EXPORTER_ORCHESTRATOR_ADDRESS_SECONDARY"))
 
 	// Retrieve fetch intervals.
 	infoFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_INFO_FETCH_INTERVAL", infoFetchIntervalDefault)


### PR DESCRIPTION
This commit migrates the `orch_info_exporter` to the
[Livepeer
subgraph](https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one/graphql)
endpoint (see #64).
