### PR TITLE
feat: add Livepeer X-Device-ID header

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -3,4 +3,5 @@ package constants
 
 const (
 	LivePeerSubgraphEndpoint = "https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one"
+	ClientIDTemplate         = "%s (livepeer-exporter)"
 )

--- a/exporters/orch_delegators_exporter/orch_delegators_exporter.go
+++ b/exporters/orch_delegators_exporter/orch_delegators_exporter.go
@@ -137,10 +137,16 @@ func NewOrchDelegatorsExporter(orchAddress string, fetchInterval time.Duration, 
 		orchDelegators:             &delegatorsResponse{},
 	}
 
+	// Create request headers.
+	headers := map[string][]string{
+		"X-Device-ID": {fmt.Sprintf(constants.ClientIDTemplate, orchAddress)},
+	}
+
 	// Initialize fetcher.
 	exporter.orchDelegatorsFetcher = fetcher.Fetcher{
-		URL:  exporter.orchDelegatorsEndpoint,
-		Data: &exporter.orchDelegators,
+		URL:     exporter.orchDelegatorsEndpoint,
+		Data:    &exporter.orchDelegators,
+		Headers: headers,
 	}
 
 	// Initialize metrics.

--- a/exporters/orch_info_exporter/orch_info_exporter.go
+++ b/exporters/orch_info_exporter/orch_info_exporter.go
@@ -407,10 +407,16 @@ func NewOrchInfoExporter(orchAddress string, fetchInterval time.Duration, update
 		orchInfo:             &orchInfo{},
 	}
 
+	// Create request headers.
+	headers := map[string][]string{
+		"X-Device-ID": {fmt.Sprintf(constants.ClientIDTemplate, orchAddress)},
+	}
+
 	// Initialize fetcher.
 	exporter.orchInfoFetcher = fetcher.Fetcher{
-		URL:  exporter.orchInfoEndpoint,
-		Data: &exporter.transcoderResponse,
+		URL:     exporter.orchInfoEndpoint,
+		Data:    &exporter.transcoderResponse,
+		Headers: headers,
 	}
 
 	// Initialize metrics.

--- a/exporters/orch_rewards_exporter/orch_rewards_exporter.go
+++ b/exporters/orch_rewards_exporter/orch_rewards_exporter.go
@@ -177,10 +177,16 @@ func NewOrchRewardsExporter(orchAddress string, fetchInterval time.Duration, upd
 		orchRewards:             &rewardEventResponse{},
 	}
 
+	// Create request headers.
+	headers := map[string][]string{
+		"X-Device-ID": {fmt.Sprintf(constants.ClientIDTemplate, orchAddress)},
+	}
+
 	// Initialize fetcher.
 	exporter.orchRewardsFetcher = fetcher.Fetcher{
-		URL:  exporter.orchRewardsEndpoint,
-		Data: &exporter.orchRewards,
+		URL:     exporter.orchRewardsEndpoint,
+		Data:    &exporter.orchRewards,
+		Headers: headers,
 	}
 
 	// Initialize metrics.

--- a/exporters/orch_score_exporter/orch_score_exporter.go
+++ b/exporters/orch_score_exporter/orch_score_exporter.go
@@ -4,6 +4,7 @@ package orch_score_exporter
 
 import (
 	"fmt"
+	"livepeer-exporter/constants"
 	"livepeer-exporter/fetcher"
 	"sync"
 	"time"
@@ -117,10 +118,16 @@ func NewOrchScoreExporter(orchAddress string, fetchInterval time.Duration, updat
 		orchScore:        &orchScore{},
 	}
 
+	// Create request headers.
+	headers := map[string][]string{
+		"X-Device-ID": {fmt.Sprintf(constants.ClientIDTemplate, orchAddress)},
+	}
+
 	// Initialize fetcher.
 	exporter.orchScoreFetcher = fetcher.Fetcher{
-		URL:  exporter.orchInfoEndpoint,
-		Data: &exporter.orchScore,
+		URL:     exporter.orchInfoEndpoint,
+		Data:    &exporter.orchScore,
+		Headers: headers,
 	}
 
 	// Initialize metrics.

--- a/exporters/orch_test_streams_exporter/orch_test_streams_exporter.go
+++ b/exporters/orch_test_streams_exporter/orch_test_streams_exporter.go
@@ -5,6 +5,7 @@ package orch_test_streams_exporter
 
 import (
 	"fmt"
+	"livepeer-exporter/constants"
 	"livepeer-exporter/fetcher"
 	"sync"
 	"time"
@@ -131,10 +132,16 @@ func NewOrchTestStreamsExporter(orchAddress string, fetchInterval time.Duration,
 		orchTestStreams:         &orchTestStreams{},
 	}
 
+	// Create request headers.
+	headers := map[string][]string{
+		"X-Device-ID": {fmt.Sprintf(constants.ClientIDTemplate, orchAddress)},
+	}
+
 	// Initialize fetcher.
 	exporter.orchTestStreamsFetcher = fetcher.Fetcher{
-		URL:  exporter.orchTestStreamsEndpoint,
-		Data: &exporter.orchTestStreams,
+		URL:     exporter.orchTestStreamsEndpoint,
+		Data:    &exporter.orchTestStreams,
+		Headers: headers,
 	}
 
 	// Initialize metrics.

--- a/exporters/orch_tickets_exporter/orch_tickets_exporter.go
+++ b/exporters/orch_tickets_exporter/orch_tickets_exporter.go
@@ -162,10 +162,16 @@ func NewOrchTicketsExporter(orchAddress string, fetchInterval time.Duration, upd
 		orchTickets:             &winningTicketRedeemedResponse{},
 	}
 
+	// Create request headers.
+	headers := map[string][]string{
+		"X-Device-ID": {fmt.Sprintf(constants.ClientIDTemplate, orchAddress)},
+	}
+
 	// Initialize fetcher.
 	exporter.orchTicketsFetcher = fetcher.Fetcher{
-		URL:  exporter.orchTicketsEndpoint,
-		Data: &exporter.orchTickets,
+		URL:     exporter.orchTicketsEndpoint,
+		Data:    &exporter.orchTickets,
+		Headers: headers,
 	}
 
 	// Initialize metrics.


### PR DESCRIPTION
This pull request adds a custom device ID header to the requests sent to the Livepeer APIs. The Livepeer team can use this header to check the exporter's API usage.
