### PR TITLE
fix(rewards_exporter): fix total gas cost metric bug

### DIFF
--- a/exporters/orch_rewards_exporter/orch_rewards_exporter.go
+++ b/exporters/orch_rewards_exporter/orch_rewards_exporter.go
@@ -245,6 +245,7 @@ func (m *OrchRewardsExporter) registerMetrics() {
 		m.NinetyDayGasCost,
 		m.YearGasCost,
 		m.RewardRound,
+		m.TotalGasCost,
 	)
 }
 


### PR DESCRIPTION
This pull request ensures that the `livepeer_orch_rewards_total_gas_cost` is correctly registered.
